### PR TITLE
Develop

### DIFF
--- a/src/Server/Application.php
+++ b/src/Server/Application.php
@@ -11,7 +11,7 @@
 
 namespace HuangYi\Http\Server;
 
-use Illuminate\Contracts\Foundation\Application as ApplicationContract;
+use Illuminate\Container\Container;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 
@@ -95,7 +95,7 @@ class Application
      */
     public function getApplication()
     {
-        if (! $this->application instanceof ApplicationContract) {
+        if (! $this->application instanceof Container) {
             $this->application = $this->loadApplication();
         }
 

--- a/src/Server/Application.php
+++ b/src/Server/Application.php
@@ -91,7 +91,7 @@ class Application
     }
 
     /**
-     * @return \Illuminate\Contracts\Foundation\Application
+     * @return \Illuminate\Container\Container
      */
     public function getApplication()
     {

--- a/src/Server/Manager.php
+++ b/src/Server/Manager.php
@@ -174,7 +174,12 @@ class Manager
         $illuminateRequest = Request::make($swooleRequest)->toIlluminate();
         $illuminateResponse = $this->getApplication()->run($illuminateRequest);
 
-        Response::make($illuminateResponse, $swooleResponse)->send();
+        $response = Response::make($illuminateResponse, $swooleResponse);
+        // To prevent 'connection[...] is closed' error.
+        if (! $this->server->exist($response->getSwooleResponse()->fd)) {
+            return;
+        }
+        $response->send();
 
         // Unset request and response.
         $swooleRequest = null;


### PR DESCRIPTION
Hi Huang-Yi,

First, thanks a lot for your amazing package and high code quality!  I did some change in 2 places.

1. I found when I tried to do some benchmark testing, sometimes it threw a 'connection[...] is closed' error. So I checked response fd before sending response to prevent this error.
2. After Lumen 5.2, the application instance didn't implement `ApplicationContract`. So I let it check  the `Container` instance to prevent a memory leak issue in Lumen.

Best Regards,
Albert Chen. 