### PR TITLE
Add support for Mac OSX

### DIFF
--- a/src/Server/Manager.php
+++ b/src/Server/Manager.php
@@ -16,6 +16,8 @@ use Swoole\Http\Server;
 
 class Manager
 {
+    const MAC_OSX = 'Darwin';
+
     /**
      * @var \Swoole\Http\Server
      */
@@ -265,6 +267,11 @@ class Manager
      */
     protected function setProcessName($process)
     {
+        // Mac OS doesn't support this function
+        if (PHP_OS === static::MAC_OSX) {
+            return;
+        }
+
         $serverName = 'swoole_http_server';
         $appName = $this->container['config']->get('app.name', 'Laravel');
 


### PR DESCRIPTION
Hi @huang-yi ,

在 Mac 作業系統中不支援更改進程名稱, 所以我讓 mac 執行時不跑 `setProcessName()`
詳情見: https://github.com/swoole/swoole-src/blob/e6da6b99437a8c04f351c86703e7c2058e63627a/swoole.c#L1171
