### PR TITLE
Fix #35

### DIFF
--- a/src/Laravel/AppPool.php
+++ b/src/Laravel/AppPool.php
@@ -6,6 +6,7 @@ use HuangYi\Shadowfax\Contracts\AppPool as PoolContract;
 use HuangYi\Shadowfax\Events\AppPushingEvent;
 use HuangYi\Shadowfax\HasEventDispatcher;
 use Illuminate\Contracts\Container\Container;
+use Illuminate\Support\Facades\Facade;
 
 class AppPool implements PoolContract
 {
@@ -47,6 +48,8 @@ class AppPool implements PoolContract
      */
     public function pop(): Container
     {
+        Facade::clearResolvedInstances();
+
         return $this->app;
     }
 

--- a/tests/Laravel/AppPoolTest.php
+++ b/tests/Laravel/AppPoolTest.php
@@ -5,6 +5,7 @@ namespace HuangYi\Shadowfax\Tests\Laravel;
 use HuangYi\Shadowfax\Laravel\AppPool;
 use HuangYi\Shadowfax\Laravel\FrameworkBootstrapper;
 use Illuminate\Container\Container;
+use Illuminate\Support\Facades\Facade;
 use Mockery as m;
 use PHPUnit\Framework\TestCase;
 
@@ -20,6 +21,18 @@ class AppPoolTest extends TestCase
     }
 
 
+    public function testFacadeInstancesCleared()
+    {
+        $pool = new AppPool($this->mockFrameworkBootstrapper());
+
+        ShadowfaxFacade::setResolvedInstances(['foo' => 'bar']);
+
+        $pool->pop();
+
+        $this->assertEmpty(ShadowfaxFacade::getResolvedInstances());
+    }
+
+
     protected function mockFrameworkBootstrapper()
     {
         $bootstrapper = m::mock(FrameworkBootstrapper::class);
@@ -30,5 +43,19 @@ class AppPoolTest extends TestCase
             ->andReturn(new Container);
 
         return $bootstrapper;
+    }
+}
+
+
+class ShadowfaxFacade extends Facade
+{
+    public static function setResolvedInstances(array $instances)
+    {
+        static::$resolvedInstance = $instances;
+    }
+
+    public static function getResolvedInstances()
+    {
+        return static::$resolvedInstance;
     }
 }


### PR DESCRIPTION
Clear all of the resolved instance in Facade when popping Laravel Application. (Fix #35) 